### PR TITLE
Ignore ENIs returning 404 on metadata request

### DIFF
--- a/pkg/awsutils/awsutils.go
+++ b/pkg/awsutils/awsutils.go
@@ -84,7 +84,8 @@ var (
 		},
 		[]string{"fn", "error"},
 	)
-	prometheusRegistered = false
+	prometheusRegistered   = false
+	errENIMetadataNotFound = fmt.Errorf("ENI metadata not found")
 )
 
 // APIs defines interfaces calls for adding/getting/deleting ENIs/secondary IPs. The APIs are not thread-safe.
@@ -385,6 +386,10 @@ func (cache *EC2InstanceMetadataCache) GetAttachedENIs() (eniList []ENIMetadata,
 	for _, macStr := range macsStrs {
 		eniMetadata, err := cache.getENIMetadata(macStr)
 		if err != nil {
+			if errors.Cause(err) == errENIMetadataNotFound {
+				log.Debugf("Metadata not found for eni %s. Ignoring, assuming stale metadata cache to be the cause.")
+				continue
+			}
 			return nil, errors.Wrapf(err, "get attached enis: failed to retrieve eni metadata for eni: %s", macStr)
 		}
 
@@ -456,7 +461,13 @@ func (cache *EC2InstanceMetadataCache) getENIDeviceNumber(eniMAC string) (string
 	awsAPILatency.WithLabelValues("GetMetadata", fmt.Sprint(err != nil)).Observe(msSince(start))
 	if err != nil {
 		awsAPIErrInc("GetMetadata", err)
-		log.Errorf("Failed to retrieve the device-number of eni %s,  %v", eniMAC, err)
+		logMessage := fmt.Sprintf("Failed to retrieve the device-number of eni %s,  %v", eniMAC, err)
+		if isMetadataNotFoundError(err) {
+			log.Warn(logMessage)
+			err = errENIMetadataNotFound
+		} else {
+			log.Errorf(logMessage)
+		}
 		return "", 0, errors.Wrapf(err, "failed to retrieve device-number for eni %s",
 			eniMAC)
 	}
@@ -690,6 +701,13 @@ func containsPrivateIPAddressLimitExceededError(err error) bool {
 		return aerr.Code() == "PrivateIpAddressLimitExceeded"
 	}
 	return false
+}
+
+func isMetadataNotFoundError(err error) bool {
+	aerr, ok := err.(awserr.Error)
+	return ok &&
+		aerr.Code() == "EC2MetadataError" &&
+		strings.Contains(aerr.OrigErr().Error(), "404 - Not Found")
 }
 
 func awsAPIErrInc(api string, err error) {


### PR DESCRIPTION
This fixes an issue where sometimes new ENIs cannot be attached to an instance,
if an ENI was recently detached from the same instance. There's been cases
where this scenario causes new ENI attaching to be impossible for more than
5 minutes, causing new pods to fail to start on that node.

An example failure scenario:
* More than enough IPs available in the warm IP pool
* An ENI is deleted/detached
* Many CronJobs get scheduled on the node
* Not enough IPs available in the warm IP pool
* An ENI is added/attached
* IP allocation from the recently attached ENI fails for 5+ minutes because:
  * `network/interfaces/macs/` includes the recently detached ENI's mac, but
  * `network/interfaces/macs/<MAC>/device-number/` returns 404 Not Found
* New pods don't get IPs, because the IPs from the recently attached ENI are
  not available until the metadata cache clears

Log excerpts showing this behavior will be added to the upstream PR.